### PR TITLE
Fixes a bug with double test cases

### DIFF
--- a/NUnit HTML Report Generator/ExampleResults.xml
+++ b/NUnit HTML Report Generator/ExampleResults.xml
@@ -30,8 +30,8 @@
                           <message><![CDATA[No valid data]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" description="Mock Test #1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" description="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest1('a', 'b')" description="Mock Test #1" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Tests.Assemblies.MockTestFixture.MockTest2(1.5, 2)" description="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" executed="True" result="Success" success="True" time="0.000" asserts="0">
                         <categories>
                           <category name="MockCategory" />
                         </categories>

--- a/NUnit HTML Report Generator/Program.cs
+++ b/NUnit HTML Report Generator/Program.cs
@@ -483,8 +483,18 @@ namespace Jatech.NUnit
                 name = testCase.Attribute("name").Value;
                 result = testCase.Attribute("result").Value;
 
-                // Remove namespace if included
-                name = name.Substring(name.LastIndexOf('.') + 1, name.Length - name.LastIndexOf('.') - 1);
+                // Remove namespace if included, which is all text before the last point, the last point being before any parenthesis (for the test cases)
+                int parenthesisPosition = name.LastIndexOf('(');
+                if (parenthesisPosition >= 0)
+                {
+                    parenthesisPosition = parenthesisPosition - 1;
+                }
+                else
+                {
+                    parenthesisPosition = name.Length - 1;
+                }
+
+                name = name.Substring(name.LastIndexOf('.', parenthesisPosition) + 1, name.Length - name.LastIndexOf('.', parenthesisPosition) - 1);
 
                 html.AppendLine("<div class=\"panel ");
 


### PR DESCRIPTION
When a test case contains a double (with a dot) the name of the test case was stripped from the dot position.
