### PR TITLE
The error message should be placed in a pre tag

### DIFF
--- a/NUnit HTML Report Generator/Program.cs
+++ b/NUnit HTML Report Generator/Program.cs
@@ -519,7 +519,7 @@ namespace Jatech.NUnit
                 // Add failure messages if available
                 if (testCase.Elements("failure").Count() == 1)
                 {
-                    html.AppendLine(string.Format("<div><strong>Message:</strong> {0}</div>", testCase.Element("failure").Element("message").Value));
+                    html.AppendLine(string.Format("<div><strong>Message:</strong> <pre>{0}</pre></div>", testCase.Element("failure").Element("message").Value));
                     html.AppendLine(string.Format("<div><strong>Stack Trace:</strong> <pre>{0}</pre></div>", testCase.Element("failure").Element("stack-trace").Value));
                 }
 


### PR DESCRIPTION
The error message should be placed in a pre tag since it normally contains line breaks and expects monospacing for ASCII-style graphs.
